### PR TITLE
Crash while using one instance of same HTTPClient more then once

### DIFF
--- a/Sources/HTTP/Responder/HTTPClient.swift
+++ b/Sources/HTTP/Responder/HTTPClient.swift
@@ -165,6 +165,7 @@ private final class HTTPClientResponseParser: ChannelInboundHandler {
                     body: data.flatMap { HTTPBody(data: $0) } ?? HTTPBody()
                 )
                 ctx.fireChannelRead(wrapOutboundOut(res))
+                state = .ready
             }
         }
     }


### PR DESCRIPTION
Second request with same instance of HTTPClient crashes, the state did not reseted