### PR TITLE
Workaround for resetting connection when handler throw error

### DIFF
--- a/Sources/HTTP/Responder/HTTPClient.swift
+++ b/Sources/HTTP/Responder/HTTPClient.swift
@@ -19,15 +19,18 @@ public final class HTTPClient {
     ///     - hostname: Remote server's hostname.
     ///     - port: Remote server's port, defaults to 80 for TCP and 443 for TLS.
     ///     - worker: `Worker` to perform async work on.
+    ///     - onError: Optional closure, which fires when QueueHandler catch error
     /// - returns: A `Future` containing the connected `HTTPClient`.
     public static func connect(
         scheme: HTTPScheme = .http,
         hostname: String,
         port: Int? = nil,
-        on worker: Worker
+        on worker: Worker,
+        onError: ((Error) -> ())? = nil
     ) -> Future<HTTPClient> {
         let handler = QueueHandler<HTTPResponse, HTTPRequest>(on: worker) { error in
             ERROR("HTTPClient: \(error)")
+            onError?(error)
         }
         let bootstrap = ClientBootstrap(group: worker.eventLoop)
             .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)


### PR DESCRIPTION
I received multiple times error HTTPClient: uncleanShutdown [HTTPClient.swift:30]. After which HTTPClient became useless, because Channel becomes inactive and unregistered soon.
As I understand from explanation of @Cory Benfield:

> That looks like a NIO error to me: uncleanShutdown is thrown by the `OpenSSLClientHandler` in situations where the remote party has sent EOF without sending a TLS CLOSE_NOTIFY.

My workaround's goal is to propagate QueueHandler errors to HTTPClient callers, so that we can reconnect to remote server (create new HTTPClient). This is critical for servers, that send multiple similar requests, because creating new connection every time is very expensive (especially for https hosts).