### PR TITLE
add support for HEAD method

### DIFF
--- a/Sources/HTTP/Responder/HTTPClient.swift
+++ b/Sources/HTTP/Responder/HTTPClient.swift
@@ -27,7 +27,7 @@ public final class HTTPClient {
         on worker: Worker
     ) -> Future<HTTPClient> {
         let handler = QueueHandler<HTTPResponse, HTTPRequest>(on: worker) { error in
-            ERROR("HTTPClient: \(error)")
+            ERROR("[HTTPClient] \(error)")
         }
         let bootstrap = ClientBootstrap(group: worker.eventLoop)
             .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)

--- a/Sources/HTTP/Utilities/HTTPError.swift
+++ b/Sources/HTTP/Utilities/HTTPError.swift
@@ -35,7 +35,7 @@ public struct HTTPError: Debuggable {
 
 /// For printing un-handleable errors.
 func ERROR(_ string: @autoclosure () -> String, file: StaticString = #file, line: Int = #line) {
-    print("[HTTP] \(string()) [\(file.description.split(separator: "/").last!):\(line)]")
+    print("[ERROR] [HTTP] \(string()) [\(file.description.split(separator: "/").last!):\(line)]")
 }
 
 /// For printing debug info.

--- a/Tests/HTTPTests/HTTPClientTests.swift
+++ b/Tests/HTTPTests/HTTPClientTests.swift
@@ -26,10 +26,6 @@ class HTTPClientTests: XCTestCase {
         try testURL("http://zombo.com", contains: "<title>ZOMBO</title>")
     }
 
-    func testRomans() throws {
-        try testURL("http://romansgohome.com", times: 1, contains: "Romans Go Home!")
-    }
-
     func testAmazonWithTLS() throws {
         try testURL("https://www.amazon.com", contains: "Amazon.com, Inc.")
     }
@@ -45,7 +41,6 @@ class HTTPClientTests: XCTestCase {
         ("testGoogleAPIsFCM", testGoogleAPIsFCM),
         ("testExampleCom", testExampleCom),
         ("testZombo", testZombo),
-        ("testRomans", testRomans),
         ("testAmazonWithTLS", testAmazonWithTLS),
         ("testQuery", testQuery),
     ]

--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,12 @@ jobs:
       - run: 
           name: Run unit tests
           command: swift test
+
+  linux-release:
+    docker:
+      - image: codevapor/swift:4.1
+    steps:
+      - checkout
       - run: 
           name: Compile code with optimizations
           command: swift build -c release
@@ -49,6 +55,7 @@ workflows:
     jobs:
       - linux
       - linux-vapor
+      - linux-release
       # - macos
 
   nightly:


### PR DESCRIPTION
- [x] HTTP server skips body serialization for HEAD requests
- [x] HTTP server now forwards HEAD requests as GET requests to the responder