### PR TITLE
eliminate warnings for Swift 4.1

### DIFF
--- a/Sources/HTTP/Parser/ParseResults.swift
+++ b/Sources/HTTP/Parser/ParseResults.swift
@@ -55,8 +55,13 @@ extension ParseResults {
     static func remove(from parser: inout http_parser) {
         if let results = parser.data {
             let pointer = results.assumingMemoryBound(to: ParseResults.self)
+            #if swift(>=4.1)
+            pointer.deinitialize(count: 1)
+            pointer.deallocate()
+            #else
             pointer.deinitialize()
             pointer.deallocate(capacity: 1)
+            #endif
         }
     }
     

--- a/Sources/SMTP/Utility/NSUUID+SMTPMessageID.swift
+++ b/Sources/SMTP/Utility/NSUUID+SMTPMessageID.swift
@@ -17,8 +17,13 @@ extension NSUUID {
     static internal func currentHostName() -> String {
         let hname = UnsafeMutablePointer<Int8>.allocate(capacity: Int(NI_MAXHOST))
         defer {
+            #if swift(>=4.1)
+            hname.deinitialize(count: Int(NI_MAXHOST))
+            hname.deallocate()
+            #else
             hname.deinitialize()
             hname.deallocate(capacity: Int(NI_MAXHOST))
+            #endif
         }
         let r = gethostname(hname, Int(NI_MAXHOST))
         if r < 0 || hname[0] == 0 {

--- a/Tests/HTTPTests/HTTPBodyTests.swift
+++ b/Tests/HTTPTests/HTTPBodyTests.swift
@@ -15,7 +15,11 @@ class HTTPBodyTests: XCTestCase {
             let stream = TestStream()
             _ = try stream.write("GET / HTTP/1.1")
             _ = try stream.writeLineEnd()
+            #if swift(>=4.0)
+            _ = try stream.write("Content-Length: \(expected.count.description)")
+            #else
             _ = try stream.write("Content-Length: \(expected.characters.count.description)")
+            #endif
             _ = try stream.writeLineEnd()
             _ = try stream.writeLineEnd()
             _ = try stream.write(expected)

--- a/Tests/HTTPTests/HTTPParsingTests.swift
+++ b/Tests/HTTPTests/HTTPParsingTests.swift
@@ -4,6 +4,7 @@ import XCTest
 import Transport
 @testable import HTTP
 
+import XCTest
 class HTTPParsingTests: XCTestCase {
     static let allTests = [
        ("testParser", testParser),
@@ -23,7 +24,11 @@ class HTTPParsingTests: XCTestCase {
         data += "Accept-Language: en-us\r\n"
         data += "Cookie: 1=1;2=2\r\n"
         data += "Content-Type: application/json; charset=utf-8\r\n"
+        #if swift(>=4.0)
+        data += "Content-Length: \(content.count)\r\n"
+        #else
         data += "Content-Length: \(content.characters.count)\r\n"
+        #endif
         data += "\r\n"
         data += content
 
@@ -83,7 +88,11 @@ class HTTPParsingTests: XCTestCase {
         data += "Host: localhost:8080\r\n"
         data += "Cookie: 1=1;2=2\r\n"
         data += "Content-Type: application/json; charset=utf-8\r\n"
+        #if swift(>=4.0)
+        data += "Content-Length: \(content.count)\r\n"
+        #else
         data += "Content-Length: \(content.characters.count)\r\n"
+        #endif
         data += "\r\n"
         data += content
 


### PR DESCRIPTION
not sure why the other 2 commits insist on being in the branch.