### PR TITLE
Fix RFC1123 Race Conditions

### DIFF
--- a/Sources/HTTP/Utilities/RFC1123.swift
+++ b/Sources/HTTP/Utilities/RFC1123.swift
@@ -37,6 +37,9 @@ extension Date {
 
 /// Performant method for generating RFC1123 date headers.
 internal struct RFC1123DateCache {
+    /// Currently cached time components.
+    private var cachedTimeComponents: (key: time_t, components: COperatingSystem.tm)?
+
     /// Currently cached timestamp.
     private var cachedTimestamp: (timestamp: String, expiration: Int)?
 
@@ -59,7 +62,8 @@ internal struct RFC1123DateCache {
         if let cached = cachedTimeComponents, cached.key == key {
             dateComponents = cached.components
         } else {
-            let tc = gmtime(&date).pointee
+            var tc = tm.init()
+            gmtime_r(&date, &tc)
             dateComponents = tc
             cachedTimeComponents = (key: key, components: tc)
         }
@@ -124,8 +128,6 @@ private let stringNumbers = [
     "80", "81", "82", "83", "84", "85", "86", "87", "88", "89",
     "90", "91", "92", "93", "94", "95", "96", "97", "98", "99"
 ]
-
-private var cachedTimeComponents: (key: time_t, components: COperatingSystem.tm)?
 
 private let secondsInDay = 60 * 60 * 24
 private let accuracy: Int = 1 // seconds


### PR DESCRIPTION
Under full concurrent load, RFC1123 can crash due to two race conditions:

`gmtime` race:
https://pastebin.com/ktyTWQEM

`cachedTimeComponents` race:
<img width="962" alt="screen shot 2018-05-28 at 01 55 45" src="https://user-images.githubusercontent.com/18578250/40620822-f4bb3530-62a2-11e8-916a-038c29678a7f.png">

Thanks @MrMage and @grundoon for the support!