### PR TITLE
Send close header if the request 'keep alive' is false

### DIFF
--- a/Sources/HTTP/Responder/HTTPServer.swift
+++ b/Sources/HTTP/Responder/HTTPServer.swift
@@ -224,6 +224,11 @@ private final class HTTPServerHandler<R>: ChannelInboundHandler where R: HTTPSer
             self.errorHandler(error)
             ctx.close(promise: nil)
         }
+        res.whenComplete {
+            if !head.isKeepAlive {
+                ctx.close(promise: nil)
+            }
+        }
     }
 
     /// Serializes the `HTTPResponse`.

--- a/Sources/HTTP/Responder/HTTPServer.swift
+++ b/Sources/HTTP/Responder/HTTPServer.swift
@@ -219,15 +219,14 @@ private final class HTTPServerHandler<R>: ChannelInboundHandler where R: HTTPSer
                 }
             }
             self.serialize(res, for: head, ctx: ctx)
+
+            if !head.isKeepAlive {
+                ctx.close(promise: nil)
+            }
         }
         res.whenFailure { error in
             self.errorHandler(error)
             ctx.close(promise: nil)
-        }
-        res.whenComplete {
-            if !head.isKeepAlive {
-                ctx.close(promise: nil)
-            }
         }
     }
 

--- a/Sources/HTTP/Responder/HTTPServer.swift
+++ b/Sources/HTTP/Responder/HTTPServer.swift
@@ -246,14 +246,7 @@ private final class HTTPServerHandler<R>: ChannelInboundHandler where R: HTTPSer
 
         if !connectionHeaders.contains("keep-alive") && !connectionHeaders.contains("close") {
             // the user hasn't pre-set either 'keep-alive' or 'close', so we might need to add headers
-            switch reqhead.isKeepAlive {
-            case true:
-                // the request has 'Connection: keep-alive', we should mirror that
-                reshead.headers.add(name: "Connection", value: "keep-alive")
-            case false:
-                // the request has 'Connection: close', we should mirror that
-                reshead.headers.add(name: "Connection", value: "close")
-            }
+            reshead.headers.add(name: "Connection", value: reqhead.isKeepAlive ? "keep-alive" : "close")
         }
 
         // begin serializing


### PR DESCRIPTION
Following the `NIOHTTP1Server` example of SwiftNIO, we send the close header if the request "keep alive" is false.

Tested it in the conditions that it was throwing an error (attached below), with this change it's working as expected.

```
[ ERROR ] data received after completed connection: close message ([...]/Sources/Vapor/Logging/Logger+LogError.swift:32)
```

Fixes: https://github.com/vapor/http/issues/305