### PR TITLE
Allow Empty Value in Cookie

### DIFF
--- a/Sources/HTTP/Cookies/HTTPCookieValue.swift
+++ b/Sources/HTTP/Cookies/HTTPCookieValue.swift
@@ -22,7 +22,7 @@ public struct HTTPCookieValue: ExpressibleByStringLiteral {
         var name: String
         var string: String
 
-        let parts = header.value.split(separator: "=", maxSplits: 1)
+        let parts = header.value.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
         switch parts.count {
         case 2:
             name = String(parts[0]).trimmingCharacters(in: .whitespaces)

--- a/Tests/HTTPTests/HTTPTests.swift
+++ b/Tests/HTTPTests/HTTPTests.swift
@@ -7,11 +7,19 @@ class HTTPTests: XCTestCase {
         guard let (name, value) = HTTPCookieValue.parse("id=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Secure; HttpOnly") else {
             throw HTTPError(identifier: "cookie", reason: "Could not parse test cookie")
         }
-
         XCTAssertEqual(name, "id")
+        XCTAssertEqual(value.string, "a3fWa")
         XCTAssertEqual(value.expires, Date(rfc1123: "Wed, 21 Oct 2015 07:28:00 GMT"))
         XCTAssertEqual(value.isSecure, true)
         XCTAssertEqual(value.isHTTPOnly, true)
+        
+        guard let cookie: (name: String, value: HTTPCookieValue) = HTTPCookieValue.parse("vapor=; Secure; HttpOnly") else {
+            throw HTTPError(identifier: "cookie", reason: "Could not parse test cookie")
+        }
+        XCTAssertEqual(cookie.name, "vapor")
+        XCTAssertEqual(cookie.value.string, "")
+        XCTAssertEqual(cookie.value.isSecure, true)
+        XCTAssertEqual(cookie.value.isHTTPOnly, true)
     }
     
     func testCookieIsSerializedCorrectly() throws {


### PR DESCRIPTION
Allows `vapor-session=;` as a valid cookie, resulting in:

```swift
let cookie: (name: String, value: HTTPCookieValue) = HTTPCookieValue.parse("vapor=; Secure; HttpOnly")
// cookie.name == "vapor"
// cookie.value.string == ""
```