### PR TITLE
Support SNI

### DIFF
--- a/Sources/HTTP/Responder/HTTPClient.swift
+++ b/Sources/HTTP/Responder/HTTPClient.swift
@@ -38,7 +38,7 @@ public final class HTTPClient {
             .connectTimeout(connectTimeout)
             .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .channelInitializer { channel in
-                return scheme.configureChannel(channel).then {
+                return scheme.configureChannel(channel, hostname).then {
                     let defaultHandlers: [ChannelHandler] = [
                         HTTPRequestEncoder(),
                         HTTPResponseDecoder(),

--- a/Sources/HTTP/Responder/HTTPClientProtocolUpgrader.swift
+++ b/Sources/HTTP/Responder/HTTPClientProtocolUpgrader.swift
@@ -23,7 +23,7 @@ extension HTTPClient {
         let bootstrap = ClientBootstrap(group: worker.eventLoop)
             .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .channelInitializer { channel in
-                return scheme.configureChannel(channel).then { _ in
+                return scheme.configureChannel(channel, hostname).then { _ in
                     return channel.pipeline.add(name: "HTTPRequestEncoder", handler: HTTPRequestEncoder(), first: false).then { _ in
                         return channel.pipeline.add(name: "HTTPResponseDecoder", handler: HTTPResponseDecoder(), first: false).then { _ in
                             return channel.pipeline.add(handler: handler, first: false)

--- a/Sources/HTTP/Utilities/String+IsIPAddress.swift
+++ b/Sources/HTTP/Utilities/String+IsIPAddress.swift
@@ -1,0 +1,12 @@
+extension String {
+    func isIPAddress() -> Bool {
+        // We need some scratch space to let inet_pton write into.
+        var ipv4Addr = in_addr()
+        var ipv6Addr = in6_addr()
+        
+        return self.withCString { ptr in
+            return inet_pton(AF_INET, ptr, &ipv4Addr) == 1 ||
+                inet_pton(AF_INET6, ptr, &ipv6Addr) == 1
+        }
+    }
+}

--- a/Tests/HTTPTests/HTTPClientTests.swift
+++ b/Tests/HTTPTests/HTTPClientTests.swift
@@ -29,6 +29,10 @@ class HTTPClientTests: XCTestCase {
     func testAmazonWithTLS() throws {
         try testURL("https://www.amazon.com", contains: "Amazon.com, Inc.")
     }
+    
+    func testSNIWebsite() throws {
+        try testURL("https://chrismeller.com", contains: "Chris")
+    }
 
     func testQuery() throws {
         try testURL("http://httpbin.org/get?foo=bar", contains: "bar")
@@ -42,6 +46,7 @@ class HTTPClientTests: XCTestCase {
         ("testExampleCom", testExampleCom),
         ("testZombo", testZombo),
         ("testAmazonWithTLS", testAmazonWithTLS),
+        ("testSNIWebsite", testSNIWebsite),
         ("testQuery", testQuery),
     ]
 }


### PR DESCRIPTION
Fix for https://github.com/vapor/http/issues/313

String.isIpAddress() was copied from NIOSSL as it's internal there.