### PR TITLE
Fix missing port number in Host HTTP header

### DIFF
--- a/Sources/HTTP/Responder/HTTPClient.swift
+++ b/Sources/HTTP/Responder/HTTPClient.swift
@@ -34,6 +34,14 @@ public final class HTTPClient {
             ERROR("[HTTPClient] \(error)")
             onError(error)
         }
+        
+        let hostnameHeaderValue: String
+        if let port = port, port != scheme.defaultPort {
+            hostnameHeaderValue = "\(hostname):\(port)"
+        } else {
+            hostnameHeaderValue = hostname
+        }
+        
         let bootstrap = ClientBootstrap(group: worker.eventLoop)
             .connectTimeout(connectTimeout)
             .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -42,7 +50,7 @@ public final class HTTPClient {
                     let defaultHandlers: [ChannelHandler] = [
                         HTTPRequestEncoder(),
                         HTTPResponseDecoder(),
-                        HTTPClientRequestSerializer(hostname: hostname),
+                        HTTPClientRequestSerializer(hostname: hostnameHeaderValue),
                         HTTPClientResponseParser()
                     ]
                     return channel.pipeline.addHandlers(defaultHandlers + [handler], first: false)

--- a/Sources/HTTP/Responder/HTTPClient.swift
+++ b/Sources/HTTP/Responder/HTTPClient.swift
@@ -131,6 +131,7 @@ private final class HTTPClientRequestSerializer: ChannelOutboundHandler {
         var headers = req.headers
         headers.add(name: .host, value: hostname)
         headers.replaceOrAdd(name: .userAgent, value: "Vapor/3.0 (Swift)")
+        headers.replaceOrAdd(name: .acceptEncoding, value: "identity")
         var httpHead = HTTPRequestHead(version: req.version, method: req.method, uri: req.url.absoluteString)
         httpHead.headers = headers
         ctx.write(wrapOutboundOut(.head(httpHead)), promise: nil)

--- a/Tests/HTTPTests/HTTPClientTests.swift
+++ b/Tests/HTTPTests/HTTPClientTests.swift
@@ -45,7 +45,7 @@ class HTTPClientTests: XCTestCase {
             let promise: Promise<Bool>
             func respond(to request: HTTPRequest, on worker: Worker) -> EventLoopFuture<HTTPResponse> {
                 let host = request.headers.firstValue(name: HTTPHeaderName.host)!
-                promise.succeed(result: host.contains("5000"))
+                promise.succeed(result: host.hasSuffix(":5000"))
                 return worker.future().map {
                     return HTTPResponse(status: .ok)
                 }

--- a/Tests/HTTPTests/HTTPClientTests.swift
+++ b/Tests/HTTPTests/HTTPClientTests.swift
@@ -33,6 +33,34 @@ class HTTPClientTests: XCTestCase {
     func testQuery() throws {
         try testURL("http://httpbin.org/get?foo=bar", contains: "bar")
     }
+    
+    func testClientHostHeaderPortSpecification() throws {
+        
+        class Responder: HTTPServerResponder {
+            
+            init(promise: Promise<Bool>) {
+                self.promise = promise
+            }
+            
+            let promise: Promise<Bool>
+            func respond(to request: HTTPRequest, on worker: Worker) -> EventLoopFuture<HTTPResponse> {
+                let host = request.headers.firstValue(name: HTTPHeaderName.host)!
+                promise.succeed(result: host.contains("5000"))
+                return worker.future().map {
+                    return HTTPResponse(status: .ok)
+                }
+            }
+        }
+        
+        let worker = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let promise = worker.next().newPromise(of: Bool.self)
+        let responder = Responder(promise: promise)
+        let _ = try HTTPServer.start(hostname: "localhost", port: 5000, responder: responder, on: worker).wait()
+        let client = try HTTPClient.connect(hostname: "localhost", port: 5000, on: worker).wait()
+        let _ = try client.send(HTTPRequest(url: "/")).wait()
+        XCTAssertTrue(try promise.futureResult.wait(), "Client didn't add port to Host header")
+        
+    }
 
     static let allTests = [
         ("testHTTPBin418", testHTTPBin418),
@@ -43,6 +71,7 @@ class HTTPClientTests: XCTestCase {
         ("testZombo", testZombo),
         ("testAmazonWithTLS", testAmazonWithTLS),
         ("testQuery", testQuery),
+        ("testClientHostHeaderPortSpecification", testClientHostHeaderPortSpecification)
     ]
 }
 

--- a/Tests/HTTPTests/HTTPTests.swift
+++ b/Tests/HTTPTests/HTTPTests.swift
@@ -105,34 +105,6 @@ class HTTPTests: XCTestCase {
             XCTAssert(error is ChannelError)
         }
     }
-    
-    func testClientHostHeaderPortSpecification() throws {
-        
-        class Responder: HTTPServerResponder {
-            
-            init(promise: Promise<Bool>) {
-                self.promise = promise
-            }
-            
-            let promise: Promise<Bool>
-            func respond(to request: HTTPRequest, on worker: Worker) -> EventLoopFuture<HTTPResponse> {
-                let host = request.headers.firstValue(name: HTTPHeaderName.host)!
-                promise.succeed(result: host.contains("5000"))
-                return worker.future().map {
-                    return HTTPResponse(status: .ok)
-                }
-            }
-        }
-        
-        let worker = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let promise = worker.next().newPromise(of: Bool.self)
-        let responder = Responder(promise: promise)
-        let _ = try HTTPServer.start(hostname: "localhost", port: 5000, responder: responder, on: worker).wait()
-        let client = try HTTPClient.connect(hostname: "localhost", port: 5000, on: worker).wait()
-        let _ = try client.send(HTTPRequest(url: "/")).wait()
-        XCTAssertTrue(try promise.futureResult.wait(), "Client didn't add port to Host header")
-        
-    }
 
     static let allTests = [
         ("testCookieParse", testCookieParse),

--- a/Tests/HTTPTests/HTTPTests.swift
+++ b/Tests/HTTPTests/HTTPTests.swift
@@ -105,6 +105,34 @@ class HTTPTests: XCTestCase {
             XCTAssert(error is ChannelError)
         }
     }
+    
+    func testClientHostHeaderPortSpecification() throws {
+        
+        class Responder: HTTPServerResponder {
+            
+            init(promise: Promise<Bool>) {
+                self.promise = promise
+            }
+            
+            let promise: Promise<Bool>
+            func respond(to request: HTTPRequest, on worker: Worker) -> EventLoopFuture<HTTPResponse> {
+                let host = request.headers.firstValue(name: HTTPHeaderName.host)!
+                promise.succeed(result: host.contains("5000"))
+                return worker.future().map {
+                    return HTTPResponse(status: .ok)
+                }
+            }
+        }
+        
+        let worker = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let promise = worker.next().newPromise(of: Bool.self)
+        let responder = Responder(promise: promise)
+        let _ = try HTTPServer.start(hostname: "localhost", port: 5000, responder: responder, on: worker).wait()
+        let client = try HTTPClient.connect(hostname: "localhost", port: 5000, on: worker).wait()
+        let _ = try client.send(HTTPRequest(url: "/")).wait()
+        XCTAssertTrue(try promise.futureResult.wait(), "Client didn't add port to Host header")
+        
+    }
 
     static let allTests = [
         ("testCookieParse", testCookieParse),


### PR DESCRIPTION
This fixes an issue where the port wasn't included in requests Host header. Port is now included if it is not the default port for the scheme.