### PR TITLE
fix ssl unclean shutdown

### DIFF
--- a/Sources/NetKit/Server/HTTPServerHandler.swift
+++ b/Sources/NetKit/Server/HTTPServerHandler.swift
@@ -50,7 +50,7 @@ final class HTTPServerHandler: ChannelInboundHandler {
         let done = ctx.write(self.wrapOutboundOut(res))
         
         if !req.isKeepAlive {
-            _ = done.then {
+            _ = done.flatMap {
                 return ctx.close()
             }
         }

--- a/Sources/NetKit/WebSocket/WebSocket+Client.swift
+++ b/Sources/NetKit/WebSocket/WebSocket+Client.swift
@@ -108,7 +108,7 @@ public final class WebSocketClientUpgrader: HTTPClientProtocolUpgrader {
         return ctx.channel.pipeline.addHandlers([
             WebSocketFrameEncoder(),
             ByteToMessageHandler(WebSocketFrameDecoder(maxFrameSize: maxFrameSize))
-        ], first: false).then {
+        ], first: false).flatMap {
             self.upgradePipelineHandler(ctx.channel, upgradeResponse)
         }
     }

--- a/Sources/NetKit/WebSocket/WebSocketHandler.swift
+++ b/Sources/NetKit/WebSocket/WebSocketHandler.swift
@@ -139,7 +139,7 @@ private final class WebSocketHandler: ChannelInboundHandler {
                 data: data
         )
 
-        _ = ctx.writeAndFlush(self.wrapOutboundOut(frame)).then {
+        _ = ctx.writeAndFlush(self.wrapOutboundOut(frame)).flatMap {
             ctx.close(mode: .output)
         }
         webSocket.isClosed = true

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -24,6 +24,7 @@ extension NetKitTests.HTTPTests {
 		("testAcceptHeader", testAcceptHeader),
 		("testRemotePeer", testRemotePeer),
 		("testLargeResponseClose", testLargeResponseClose),
+		("testUncleanShutdown", testUncleanShutdown),
 	]
 }
 

--- a/Tests/NetKitTests/HTTPClientTests.swift
+++ b/Tests/NetKitTests/HTTPClientTests.swift
@@ -61,7 +61,7 @@ private func testURL(
             hostname: url.host ?? "",
             tlsConfig: tlsConfig,
             on: worker
-        )).then { client -> EventLoopFuture<HTTPResponse> in
+        )).flatMap { client -> EventLoopFuture<HTTPResponse> in
             var comps =  URLComponents()
             comps.path = url.path.isEmpty ? "/" : url.path
             comps.query = url.query


### PR DESCRIPTION
This PR adds logic to catch and discard `OpenSSLError.uncleanShutdown` if no HTTP requests are currently pending. 

Fixes https://github.com/vapor/http/issues/284.