### PR TITLE
enable cert validation by default

### DIFF
--- a/Sources/HTTP/Responder/HTTPScheme.swift
+++ b/Sources/HTTP/Responder/HTTPScheme.swift
@@ -9,7 +9,7 @@ public struct HTTPScheme {
     public static var https: HTTPScheme {
         return .init(443) { channel, hostname in
             return Future.flatMap(on: channel.eventLoop) {
-                let tlsConfiguration = TLSConfiguration.forClient(certificateVerification: .none)
+                let tlsConfiguration = TLSConfiguration.forClient()
                 let sslContext = try SSLContext(configuration: tlsConfiguration)
                 let sniName = hostname.isIPAddress() ? nil : hostname
                 let tlsHandler = try OpenSSLClientHandler(context: sslContext, serverHostname: sniName)

--- a/Tests/HTTPTests/HTTPClientTests.swift
+++ b/Tests/HTTPTests/HTTPClientTests.swift
@@ -26,8 +26,8 @@ class HTTPClientTests: XCTestCase {
         try testURL("http://zombo.com", contains: "<title>ZOMBO</title>")
     }
 
-    func testAmazonWithTLS() throws {
-        try testURL("https://www.amazon.com", contains: "Amazon.com, Inc.")
+    func testGoogleWithTLS() throws {
+        try testURL("https://www.google.com/search?q=vapor+swift", contains: "web framework")
     }
     
     func testSNIWebsite() throws {
@@ -45,7 +45,7 @@ class HTTPClientTests: XCTestCase {
         ("testGoogleAPIsFCM", testGoogleAPIsFCM),
         ("testExampleCom", testExampleCom),
         ("testZombo", testZombo),
-        ("testAmazonWithTLS", testAmazonWithTLS),
+        ("testGoogleWithTLS", testGoogleWithTLS),
         ("testSNIWebsite", testSNIWebsite),
         ("testQuery", testQuery),
     ]


### PR DESCRIPTION
This PR modifies `HTTPScheme.https` to enable certificate validation by default. Use `HTTPScheme.httpsNoCertificateValidation` for HTTPS with no certificate validation.