### PR TITLE
fix? testHTTPBinAnything failure

### DIFF
--- a/Tests/HTTPKitTests/HTTPClientTests.swift
+++ b/Tests/HTTPKitTests/HTTPClientTests.swift
@@ -11,7 +11,7 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testHTTPBinAnything() throws {
-        try testURL("http://httpbin.org/anything", contains: "http://httpbin.org/anything")
+        try testURL("http://httpbin.org/anything", contains: "://httpbin.org/anything")
     }
 
     func testGoogleAPIsFCM() throws {


### PR DESCRIPTION
Maybe just remove the schema from the `contains:` expectation to "fix" the failing test?

Even direct execution on httpbin.org is returning the "wrong" url schema:
```json
{
  "args": {},
  "data": "",
  "files": {},
  "form": {},
  "headers": {
    "Accept": "application/json",
    "Accept-Encoding": "gzip, deflate",
    "Accept-Language": "en-us",
    "Dnt": "1",
    "Host": "httpbin.org",
    "Referer": "http://httpbin.org/",
    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0.3 Safari/605.1.15"
  },
  "json": null,
  "method": "GET",
  "origin": "50.255.0.169, 50.255.0.169",
  "url": "https://httpbin.org/anything"
}
```
as does `curl`
```json
grundoon$ curl -X GET "http://httpbin.org/anything" -H "accept: application/json"
{
  "args": {},
  "data": "",
  "files": {},
  "form": {},
  "headers": {
    "Accept": "application/json",
    "Host": "httpbin.org",
    "User-Agent": "curl/7.54.0"
  },
  "json": null,
  "method": "GET",
  "origin": "50.255.0.169, 50.255.0.169",
  "url": "https://httpbin.org/anything"
}
```
might be due to `nginx` in the chain:
```
Response headers

 access-control-allow-credentials: true 
 access-control-allow-origin: * 
 connection: keep-alive 
 content-encoding: gzip 
 content-length: 332 
 content-type: application/json 
 date: Tue, 19 Feb 2019 22:52:29 GMT 
 server: nginx
```