### PR TITLE
make all HTTP bodies streaming

### DIFF
--- a/Sources/HTTPKit/Body/HTTPBodyStorage.swift
+++ b/Sources/HTTPKit/Body/HTTPBodyStorage.swift
@@ -13,7 +13,7 @@ enum HTTPBodyStorage {
     case stream(HTTPBodyStream)
 
     /// The size of the HTTP body's data.
-    /// `nil` of the body is a non-determinate stream.
+    /// `nil` is a stream.
     var count: Int? {
         switch self {
         case .data(let data): return data.count

--- a/Sources/HTTPKit/Client/HTTPClientConnection.swift
+++ b/Sources/HTTPKit/Client/HTTPClientConnection.swift
@@ -63,8 +63,8 @@ internal final class HTTPClientConnection {
                     let proxy = HTTPClientProxyHandler(hostname: hostname, port: port ?? 443) { ctx in
                         
                         // re-add HTTPDecoder since it may consider the connection to be closed
-                        _ = ctx.pipeline.remove(handler: httpResDecoder)
-                        _ = ctx.pipeline.add(handler: httpResDecoder, after: httpReqEncoder)
+                        _ = ctx.pipeline.removeHandler(httpResDecoder)
+                        _ = ctx.pipeline.addHandler(httpResDecoder, position: .after(httpReqEncoder))
                         
 
                         // if necessary, add TLS handlers
@@ -74,7 +74,7 @@ internal final class HTTPClientConnection {
                                 context: sslContext,
                                 serverHostname: hostname.isIPAddress() ? nil : hostname
                             )
-                            _ = ctx.pipeline.add(handler: tlsHandler, first: true)
+                            _ = ctx.pipeline.addHandler(tlsHandler, position: .first)
                         }
                     }
                     handlers.append(proxy)
@@ -94,7 +94,7 @@ internal final class HTTPClientConnection {
                 let upgrader = HTTPClientUpgradeHandler(otherHTTPHandlers: otherHTTPHandlers)
                 handlers.append(upgrader)
                 handlers.append(handler)
-                return channel.pipeline.addHandlers(handlers, first: false)
+                return channel.pipeline.addHandlers(handlers, position: .last)
         }
         let connectHostname: String
         let connectPort: Int

--- a/Sources/HTTPKit/Client/HTTPClientProxyHandler.swift
+++ b/Sources/HTTPKit/Client/HTTPClientProxyHandler.swift
@@ -44,7 +44,7 @@ final class HTTPClientProxyHandler: ChannelDuplexHandler, RemovableChannelHandle
         self.onConnect(ctx)
         self.buffer.forEach { ctx.write(self.wrapOutboundOut($0), promise: nil) }
         ctx.flush()
-        _ = ctx.pipeline.remove(handler: self)
+        _ = ctx.pipeline.removeHandler(self)
     }
     
     private func sendConnect(ctx: ChannelHandlerContext) {

--- a/Sources/HTTPKit/Client/HTTPClientUpgradeHandler.swift
+++ b/Sources/HTTPKit/Client/HTTPClientUpgradeHandler.swift
@@ -25,8 +25,8 @@ internal final class HTTPClientUpgradeHandler: ChannelDuplexHandler, RemovableCh
         case .pending(let upgrader):
             let res = self.unwrapInboundIn(data)
             if res.status == .switchingProtocols {
-                ctx.pipeline.remove(handler: self, promise: nil)
-                self.otherHTTPHandlers.forEach { ctx.pipeline.remove(handler: $0, promise: nil) }
+                ctx.pipeline.removeHandler(self, promise: nil)
+                self.otherHTTPHandlers.forEach { ctx.pipeline.removeHandler($0, promise: nil) }
                 upgrader.upgrade(ctx: ctx, upgradeResponse: .init(
                     version: res.version,
                     status: res.status,

--- a/Sources/HTTPKit/Exports.swift
+++ b/Sources/HTTPKit/Exports.swift
@@ -9,6 +9,5 @@ extension FixedWidthInteger {
     }
 }
 
-extension HTTPResponseDecoder: RemovableChannelHandler { }
 extension HTTPRequestEncoder: RemovableChannelHandler { }
 extension HTTPResponseCompressor: RemovableChannelHandler { }

--- a/Sources/HTTPKit/Message/HTTPHeaders.swift
+++ b/Sources/HTTPKit/Message/HTTPHeaders.swift
@@ -70,16 +70,6 @@ extension HTTPHeaders {
     }
 }
 
-extension HTTPHeaders: ExpressibleByDictionaryLiteral {
-    /// See `ExpressibleByDictionaryLiteral`
-    public init(dictionaryLiteral elements: (String, String)...) {
-        var headers = HTTPHeaders()
-        for (key, val) in elements {
-            headers.add(name: key, value: val)
-        }
-        self = headers
-    }
-}
 extension HTTPHeaders: CustomDebugStringConvertible {
     /// See `CustomDebugStringConvertible.debugDescription`
     public var debugDescription: String {

--- a/Sources/HTTPKit/Server/HTTPServer.swift
+++ b/Sources/HTTPKit/Server/HTTPServer.swift
@@ -64,7 +64,7 @@ final class HTTPServerConnection {
             
             // Set handlers that are applied to the Server's channel
             .serverChannelInitializer { channel in
-                channel.pipeline.add(handler: quiesce.makeServerChannelHandler(channel: channel))
+                channel.pipeline.addHandler(quiesce.makeServerChannelHandler(channel: channel))
             }
 
             // Set the handlers that are applied to the accepted Channels
@@ -137,7 +137,7 @@ final class HTTPServerConnection {
                 handlers.append(handler)
                 
                 // configure the pipeline
-                return channel.pipeline.addHandlers(handlers, first: false)
+                return channel.pipeline.addHandlers(handlers, position: .last)
             }
 
             // Enable TCP_NODELAY and SO_REUSEADDR for the accepted Channels

--- a/Sources/HTTPKit/Server/HTTPServerHandler.swift
+++ b/Sources/HTTPKit/Server/HTTPServerHandler.swift
@@ -42,7 +42,7 @@ final class HTTPServerHandler: ChannelInboundHandler, RemovableChannelHandler {
     
     func serialize(_ res: HTTPResponse, for req: HTTPRequest, ctx: ChannelHandlerContext) {
         switch req.body.storage {
-        case .chunkedStream(let stream):
+        case .stream(let stream):
             assert(stream.isClosed, "HTTPResponse sent while HTTPRequest had unconsumed chunked data.")
         default: break
         }

--- a/Sources/HTTPKit/Server/HTTPServerRequestDecoder.swift
+++ b/Sources/HTTPKit/Server/HTTPServerRequestDecoder.swift
@@ -12,10 +12,10 @@ final class HTTPServerRequestDecoder: ChannelInboundHandler, RemovableChannelHan
         /// This allows for performance optimization incase
         /// a body never comes
         case awaitingBody(HTTPRequestHead)
-        /// Collecting fixed-length body
-        case collectingBody(HTTPRequestHead, ByteBuffer?)
+        // first chunk
+        case awaitingEnd(HTTPRequestHead, ByteBuffer)
         /// Collecting streaming body
-        case streamingBody(HTTPChunkedStream)
+        case streamingBody(HTTPBodyStream)
     }
     
     /// Current HTTP state.
@@ -41,57 +41,35 @@ final class HTTPServerRequestDecoder: ChannelInboundHandler, RemovableChannelHan
             case .ready: self.requestState = .awaitingBody(head)
             default: assertionFailure("Unexpected state: \(self.requestState)")
             }
-        case .body(var chunk):
-            // self.logger.trace("got req body \(chunk)")
+        case .body(let chunk):
             switch self.requestState {
             case .ready: assertionFailure("Unexpected state: \(self.requestState)")
             case .awaitingBody(let head):
-                /// 1: check to see which kind of body we are parsing from the head
-                ///
-                /// short circuit on `contains(name:)` which is faster
-                /// - note: for some reason using String instead of HTTPHeaderName is faster here...
-                ///         this will be standardized when NIO gets header names
-                if head.headers.contains(name: "Transfer-Encoding"), head.headers.firstValue(name: .transferEncoding) == "chunked" {
-                    let stream = HTTPChunkedStream(on: ctx.eventLoop)
-                    self.requestState = .streamingBody(stream)
-                    self.respond(to: head, body: .init(chunked: stream), ctx: ctx)
-                } else {
-                    self.requestState = .collectingBody(head, nil)
-                }
-                
-                /// 2: perform the actual body read now
-                self.channelRead(ctx: ctx, data: data)
-            case .collectingBody(let head, let existingBody):
-                let body: ByteBuffer
-                if var existing = existingBody {
-                    if existing.readableBytes + chunk.readableBytes > self.maxBodySize {
-                        // Request size exceeded maximum, connection closed.
-                        ctx.close(promise: nil)
-                    }
-                    existing.writeBuffer(&chunk)
-                    body = existing
-                } else {
-                    body = chunk
-                }
-                self.requestState = .collectingBody(head, body)
-            case .streamingBody(let stream): _ = stream.write(.chunk(chunk))
+                self.requestState = .awaitingEnd(head, chunk)
+            case .awaitingEnd(let head, let bodyStart):
+                let stream = HTTPBodyStream(on: ctx.channel.eventLoop)
+                self.requestState = .streamingBody(stream)
+                self.fireRequestRead(head: head, body: .init(stream: stream), ctx: ctx)
+                stream.write(.chunk(bodyStart))
+                stream.write(.chunk(chunk))
+            case .streamingBody(let stream):
+                stream.write(.chunk(chunk))
             }
         case .end(let tailHeaders):
-            // self.logger.trace("got req end")
             assert(tailHeaders == nil, "Tail headers are not supported.")
             switch self.requestState {
             case .ready: assertionFailure("Unexpected state: \(self.requestState)")
-            case .awaitingBody(let head): self.respond(to: head, body: .empty, ctx: ctx)
-            case .collectingBody(let head, let body):
-                let body: HTTPBody = body.flatMap(HTTPBody.init(buffer:)) ?? .empty
-                self.respond(to: head, body: body, ctx: ctx)
-            case .streamingBody(let stream): _ = stream.write(.end)
+            case .awaitingBody(let head):
+                self.fireRequestRead(head: head, body: .empty, ctx: ctx)
+            case .awaitingEnd(let head, let chunk):
+                self.fireRequestRead(head: head, body: .init(buffer: chunk), ctx: ctx)
+            case .streamingBody(let stream): stream.write(.end)
             }
             self.requestState = .ready
         }
     }
     
-    private func respond(to head: HTTPRequestHead, body: HTTPBody, ctx: ChannelHandlerContext) {
+    private func fireRequestRead(head: HTTPRequestHead, body: HTTPBody, ctx: ChannelHandlerContext) {
         var req = HTTPRequest(
             method: head.method,
             urlString: head.uri,

--- a/Sources/HTTPKit/Server/HTTPServerResponseEncoder.swift
+++ b/Sources/HTTPKit/Server/HTTPServerResponseEncoder.swift
@@ -54,17 +54,17 @@ final class HTTPServerResponseEncoder: ChannelOutboundHandler, RemovableChannelH
                 var buffer = ctx.channel.allocator.buffer(capacity: data.count)
                 buffer.writeDispatchData(data)
                 self.writeAndflush(buffer: buffer, ctx: ctx, promise: promise)
-            case .chunkedStream(let stream):
+            case .stream(let stream):
                 stream.read { result, stream in
                     switch result {
                     case .chunk(let buffer):
-                        return ctx.writeAndFlush(self.wrapOutboundOut(.body(.byteBuffer(buffer))))
+                        ctx.writeAndFlush(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
                     case .end:
                         promise?.succeed(())
-                        return ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)))
+                        ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
                     case .error(let error):
                         promise?.fail(error)
-                        return ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)))
+                        ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
                     }
                 }
             }

--- a/Sources/HTTPKit/WebSocket/WebSocket+Client.swift
+++ b/Sources/HTTPKit/WebSocket/WebSocket+Client.swift
@@ -108,7 +108,7 @@ public final class WebSocketClientUpgrader: HTTPClientProtocolUpgrader {
         return ctx.channel.pipeline.addHandlers([
             WebSocketFrameEncoder(),
             ByteToMessageHandler(WebSocketFrameDecoder(maxFrameSize: maxFrameSize))
-        ], first: false).flatMap {
+        ], position: .first).flatMap {
             self.upgradePipelineHandler(ctx.channel, upgradeResponse)
         }
     }

--- a/Sources/HTTPKit/WebSocket/WebSocketHandler.swift
+++ b/Sources/HTTPKit/WebSocket/WebSocketHandler.swift
@@ -2,7 +2,7 @@ extension ChannelPipeline {
     /// Adds the supplied `WebSocket` to this `ChannelPipeline`.
     public func add(webSocket: WebSocket) -> EventLoopFuture<Void> {
         let handler = WebSocketHandler(webSocket: webSocket)
-        return add(handler: handler)
+        return self.addHandler(handler)
     }
 }
 


### PR DESCRIPTION
This PR changes `HTTPServerRequestDecoder`to decode all large HTTP bodies as a stream. (Large meaning the body arrives in more than one chunk).

- `HTTPBody.consumeData` and `HTTPBodyStream.drain` have been renamed to `*.consume`
- `HTTPChunkedStream` has been renamed to `HTTPBodyStream`