### PR TITLE
fix unnecessary body copying

### DIFF
--- a/Sources/HTTP/Responder/HTTPServer.swift
+++ b/Sources/HTTP/Responder/HTTPServer.swift
@@ -144,9 +144,7 @@ private final class HTTPServerHandler<R>: ChannelInboundHandler where R: HTTPSer
     /// See `ChannelInboundHandler`.
     func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
         debugOnly { assert(ctx.channel.eventLoop.inEventLoop) }
-        let part = unwrapInboundIn(data)
-        // print(self.state)
-        switch part {
+        switch unwrapInboundIn(data) {
         case .head(let head):
             debugOnly {
                 /// only perform this switch in debug mode
@@ -197,6 +195,9 @@ private final class HTTPServerHandler<R>: ChannelInboundHandler where R: HTTPSer
                 } else {
                     body = .init(buffer: self._collectingBody)
                 }
+                // drop reference so that the ByteBuffer can be uniquely referenced
+                // by the HTTPBody
+                self._collectingBody = nil
                 respond(to: head, body: body, ctx: ctx)
             case .streamingBody(let stream): _ = stream.write(.end)
             }


### PR DESCRIPTION
This PR fixes an issue that causes HTTP request body byte buffer to reallocate unnecessarily. During large file uploads, this issue quickly consumes the CPU. 

![Screen Shot 2019-03-13 at 9 23 33 PM](https://user-images.githubusercontent.com/1342803/54325513-01af5b80-45d9-11e9-9920-8524d2dd926d.png)

The reason for the copy is that `HTTPServerState` continues to hold a reference to the HTTP request `ByteBuffer` when the new chunk is written. Since the buffer is not uniquely referenced, the write triggers a copy. 

To fix this, the request body buffer is moved outside of the state enum to a member var. This ensures the ByteBuffer is uniquely referenced during body collection.