### PR TITLE
Make the `HTTPMessageDecoder.decode` extension method public

### DIFF
--- a/Sources/HTTP/Codable/HTTPMessageCoder.swift
+++ b/Sources/HTTP/Codable/HTTPMessageCoder.swift
@@ -96,7 +96,7 @@ extension JSONDecoder: HTTPMessageDecoder {
     public func decode<D, M>(_ decodable: D.Type, from message: M, maxSize: Int, on worker: Worker) throws -> EventLoopFuture<D>
         where D: Decodable, M: HTTPMessage
     {
-        guard message.contentType == .json || message.contentType == .jsonApi else {
+        guard message.contentType == .json || message.contentType == .jsonAPI else {
             throw HTTPError(identifier: "contentType", reason: "HTTP message did not have JSON-compatible content-type.")
         }
         return message.body.consumeData(max: maxSize, on: worker).map(to: D.self) { data in

--- a/Sources/HTTP/Codable/HTTPMessageCoder.swift
+++ b/Sources/HTTP/Codable/HTTPMessageCoder.swift
@@ -96,7 +96,7 @@ extension JSONDecoder: HTTPMessageDecoder {
     public func decode<D, M>(_ decodable: D.Type, from message: M, maxSize: Int, on worker: Worker) throws -> EventLoopFuture<D>
         where D: Decodable, M: HTTPMessage
     {
-        guard message.contentType == .json else {
+        guard message.contentType == .json || message.contentType == .jsonApi else {
             throw HTTPError(identifier: "contentType", reason: "HTTP message did not have JSON-compatible content-type.")
         }
         return message.body.consumeData(max: maxSize, on: worker).map(to: D.self) { data in

--- a/Sources/HTTP/Codable/HTTPMessageCoder.swift
+++ b/Sources/HTTP/Codable/HTTPMessageCoder.swift
@@ -43,7 +43,7 @@ public protocol HTTPMessageDecoder {
 extension HTTPMessageDecoder {
     /// See `HTTPMessageDecoder`.
     /// - note: This method will use a default max size of 1MB.
-    func decode<D, M>(_ decodable: D.Type, from message: M, on worker: Worker) throws -> Future<D>
+    public func decode<D, M>(_ decodable: D.Type, from message: M, on worker: Worker) throws -> Future<D>
         where D: Decodable, M: HTTPMessage
     {
         return try decode(D.self, from: message, maxSize: 1_000_000, on: worker)


### PR DESCRIPTION
Also adds support for decoding the JSON API media type (see https://jsonapi.org/format/). (Requires https://github.com/vapor/core/pull/202.)