### PR TITLE
added .https scheme with TLSConfiguration parameter

### DIFF
--- a/Sources/HTTP/Responder/HTTPScheme.swift
+++ b/Sources/HTTP/Responder/HTTPScheme.swift
@@ -7,9 +7,14 @@ public struct HTTPScheme {
 
     /// Enables TLS (SSL). Uses port `443` by default.
     public static var https: HTTPScheme {
+        let tlsConfiguration = TLSConfiguration.forClient(certificateVerification: .none)
+        return .https(tlsConfiguration: tlsConfiguration)
+    }
+    
+    /// Enables TLS (SSL). Uses port `443` by default; also allows custom TLS configuration
+    public static func https(tlsConfiguration: TLSConfiguration) -> HTTPScheme {
         return .init(443) { channel in
             return Future.flatMap(on: channel.eventLoop) {
-                let tlsConfiguration = TLSConfiguration.forClient(certificateVerification: .none)
                 let sslContext = try SSLContext(configuration: tlsConfiguration)
                 let tlsHandler = try OpenSSLClientHandler(context: sslContext)
                 return channel.pipeline.add(handler: tlsHandler)


### PR DESCRIPTION
Nothing fancy, just made public a HTTPScheme generator that accepts custom TLSConfiguration. The reason is that we need to connect to a legacy API with client certificates.

Thanks